### PR TITLE
Add changing motion magic parameters on the fly

### DIFF
--- a/src/main/java/frc/lib/io/motor/MotorIO.java
+++ b/src/main/java/frc/lib/io/motor/MotorIO.java
@@ -157,13 +157,25 @@ public interface MotorIO extends AutoCloseable {
     public default void runPosition(Angle position, PIDSlot slot) {}
 
     /**
-     * Runs the motor to a specific position using a dynamic Motion Magic request that embeds cruise
-     * velocity and acceleration directly in the control request, requiring no config update.
+     * Runs the motor to a specific position using a Motion Magic-style profiled position request
+     * with the provided cruise velocity and acceleration.
+     *
+     * <p>Implementations may either:
+     *
+     * <ul>
+     *   <li>embed the cruise velocity and acceleration directly in a dynamic control request (if
+     *       supported by the underlying controller), or
+     *   <li>apply the cruise velocity and acceleration to the controller's Motion Magic
+     *       configuration before issuing the request.
+     * </ul>
+     *
+     * <p>Callers must not assume that the motor controller's Motion Magic configuration remains
+     * unchanged after this call.
      *
      * @param position Target position.
      * @param slot PID slot index.
-     * @param cruiseVelocity Motion Magic cruise velocity embedded in the request.
-     * @param acceleration Motion Magic acceleration embedded in the request.
+     * @param cruiseVelocity Motion Magic cruise velocity to use for the motion profile.
+     * @param acceleration Motion Magic acceleration to use for the motion profile.
      */
     public default void runPosition(
             Angle position,

--- a/src/main/java/frc/lib/io/motor/MotorIO.java
+++ b/src/main/java/frc/lib/io/motor/MotorIO.java
@@ -195,26 +195,20 @@ public interface MotorIO extends AutoCloseable {
      * Runs the motor at a target velocity.
      *
      * @param velocity Desired velocity.
-     * @param acceleration Max acceleration.
      * @param slot PID slot index.
      */
-    public default void runVelocity(
-            AngularVelocity velocity, AngularAcceleration acceleration, PIDSlot slot) {}
+    public default void runVelocity(AngularVelocity velocity, PIDSlot slot) {}
 
     /**
      * Runs the motor at a target velocity using a Motion Magic velocity request that ramps to the
      * target velocity using the provided Motion Magic acceleration.
      *
      * @param velocity Desired velocity.
-     * @param acceleration Max feed-forward acceleration.
+     * @param acceleration Motion Magic acceleration used to ramp to target velocity.
      * @param slot PID slot index.
-     * @param motionMagicAcceleration Motion Magic acceleration used to ramp to target velocity.
      */
     public default void runVelocity(
-            AngularVelocity velocity,
-            AngularAcceleration acceleration,
-            PIDSlot slot,
-            AngularAcceleration motionMagicAcceleration) {}
+            AngularVelocity velocity, AngularAcceleration acceleration, PIDSlot slot) {}
 
     /**
      * Sets the position of the motor's internal encoder

--- a/src/main/java/frc/lib/io/motor/MotorIO.java
+++ b/src/main/java/frc/lib/io/motor/MotorIO.java
@@ -157,13 +157,13 @@ public interface MotorIO extends AutoCloseable {
     public default void runPosition(Angle position, PIDSlot slot) {}
 
     /**
-     * Runs the motor to a specific position with dynamic Motion Magic cruise velocity and
-     * acceleration. Updates the motor configuration before issuing the control request.
+     * Runs the motor to a specific position using a dynamic Motion Magic request that embeds cruise
+     * velocity and acceleration directly in the control request, requiring no config update.
      *
      * @param position Target position.
      * @param slot PID slot index.
-     * @param cruiseVelocity Motion Magic cruise velocity.
-     * @param acceleration Motion Magic acceleration.
+     * @param cruiseVelocity Motion Magic cruise velocity embedded in the request.
+     * @param acceleration Motion Magic acceleration embedded in the request.
      */
     public default void runPosition(
             Angle position,
@@ -190,20 +190,18 @@ public interface MotorIO extends AutoCloseable {
             AngularVelocity velocity, AngularAcceleration acceleration, PIDSlot slot) {}
 
     /**
-     * Runs the motor at a target velocity with dynamic Motion Magic cruise velocity and
-     * acceleration. Updates the motor configuration before issuing the control request.
+     * Runs the motor at a target velocity using a Motion Magic velocity request that ramps to the
+     * target velocity using the provided Motion Magic acceleration.
      *
      * @param velocity Desired velocity.
-     * @param acceleration Max acceleration.
+     * @param acceleration Max feed-forward acceleration.
      * @param slot PID slot index.
-     * @param cruiseVelocity Motion Magic cruise velocity.
-     * @param motionMagicAcceleration Motion Magic acceleration.
+     * @param motionMagicAcceleration Motion Magic acceleration used to ramp to target velocity.
      */
     public default void runVelocity(
             AngularVelocity velocity,
             AngularAcceleration acceleration,
             PIDSlot slot,
-            AngularVelocity cruiseVelocity,
             AngularAcceleration motionMagicAcceleration) {}
 
     /**

--- a/src/main/java/frc/lib/io/motor/MotorIO.java
+++ b/src/main/java/frc/lib/io/motor/MotorIO.java
@@ -157,6 +157,21 @@ public interface MotorIO extends AutoCloseable {
     public default void runPosition(Angle position, PIDSlot slot) {}
 
     /**
+     * Runs the motor to a specific position with dynamic Motion Magic cruise velocity and
+     * acceleration. Updates the motor configuration before issuing the control request.
+     *
+     * @param position Target position.
+     * @param slot PID slot index.
+     * @param cruiseVelocity Motion Magic cruise velocity.
+     * @param acceleration Motion Magic acceleration.
+     */
+    public default void runPosition(
+            Angle position,
+            PIDSlot slot,
+            AngularVelocity cruiseVelocity,
+            AngularAcceleration acceleration) {}
+
+    /**
      * Runs the motor to a specific position without a motion profile.
      *
      * @param position Target position.
@@ -173,6 +188,23 @@ public interface MotorIO extends AutoCloseable {
      */
     public default void runVelocity(
             AngularVelocity velocity, AngularAcceleration acceleration, PIDSlot slot) {}
+
+    /**
+     * Runs the motor at a target velocity with dynamic Motion Magic cruise velocity and
+     * acceleration. Updates the motor configuration before issuing the control request.
+     *
+     * @param velocity Desired velocity.
+     * @param acceleration Max acceleration.
+     * @param slot PID slot index.
+     * @param cruiseVelocity Motion Magic cruise velocity.
+     * @param motionMagicAcceleration Motion Magic acceleration.
+     */
+    public default void runVelocity(
+            AngularVelocity velocity,
+            AngularAcceleration acceleration,
+            PIDSlot slot,
+            AngularVelocity cruiseVelocity,
+            AngularAcceleration motionMagicAcceleration) {}
 
     /**
      * Sets the position of the motor's internal encoder

--- a/src/main/java/frc/lib/io/motor/MotorIOTalonFX.java
+++ b/src/main/java/frc/lib/io/motor/MotorIOTalonFX.java
@@ -94,6 +94,8 @@ public class MotorIOTalonFX implements MotorIO {
     // Caches for last-applied Motion Magic parameters (NaN = never applied)
     private double lastAppliedMmCruiseVelocity = Double.NaN;
     private double lastAppliedMmAcceleration = Double.NaN;
+    private double lastRequestedMmCruiseVelocity = Double.NaN;
+    private double lastRequestedMmAcceleration = Double.NaN;
 
     /**
      * Constructs and initializes a TalonFX motor.
@@ -109,6 +111,10 @@ public class MotorIOTalonFX implements MotorIO {
             Device.CAN main,
             TalonFXFollower... followerData) {
         currentConfig = config;
+        lastAppliedMmCruiseVelocity = config.MotionMagic.MotionMagicCruiseVelocity;
+        lastAppliedMmAcceleration = config.MotionMagic.MotionMagicAcceleration;
+        lastRequestedMmCruiseVelocity = lastAppliedMmCruiseVelocity;
+        lastRequestedMmAcceleration = lastAppliedMmAcceleration;
 
         motor = new TalonFX(main.id(), new CANBus(main.bus()));
         updateThread
@@ -400,8 +406,7 @@ public class MotorIOTalonFX implements MotorIO {
 
     /**
      * Runs the motor to a specific position using a Motion Magic request with cruise velocity and
-     * acceleration. Config is applied synchronously only when the values change to avoid
-     * unnecessary CAN bus traffic.
+     * acceleration.
      *
      * @param position Target position.
      * @param slot PID slot index.
@@ -417,18 +422,7 @@ public class MotorIOTalonFX implements MotorIO {
         double newCruise = cruiseVelocity.in(RotationsPerSecond);
         double newAccel = acceleration.in(RotationsPerSecondPerSecond);
 
-        if (newCruise != lastAppliedMmCruiseVelocity || newAccel != lastAppliedMmAcceleration) {
-            MotionMagicConfigs mmConfig = new MotionMagicConfigs();
-            mmConfig.MotionMagicCruiseVelocity = newCruise;
-            mmConfig.MotionMagicAcceleration = newAccel;
-            var status = motor.getConfigurator().apply(mmConfig, 0.05);
-            if (status.isOK()) {
-                lastAppliedMmCruiseVelocity = newCruise;
-                lastAppliedMmAcceleration = newAccel;
-            } else {
-                LOGGER.log(Level.WARNING, "Failed to apply MotionMagic config: " + status);
-            }
-        }
+        queueMotionMagicConfigUpdate(newCruise, newAccel);
 
         this.goalPosition = position;
         motor.setControl(positionControl.withPosition(position).withSlot(slot.getNum()));
@@ -459,8 +453,7 @@ public class MotorIOTalonFX implements MotorIO {
 
     /**
      * Runs the motor at a target velocity using a Motion Magic velocity request that ramps to the
-     * target velocity using the provided Motion Magic acceleration. Config is applied synchronously
-     * only when the acceleration value changes to avoid unnecessary CAN bus traffic.
+     * target velocity using the provided Motion Magic acceleration.
      *
      * @param velocity Desired velocity.
      * @param acceleration Motion Magic acceleration used to ramp to target velocity.
@@ -471,15 +464,7 @@ public class MotorIOTalonFX implements MotorIO {
             AngularVelocity velocity, AngularAcceleration acceleration, PIDSlot slot) {
         double newAccel = acceleration.in(RotationsPerSecondPerSecond);
 
-        if (newAccel != lastAppliedMmAcceleration) {
-            currentConfig.MotionMagic.MotionMagicAcceleration = newAccel;
-            var status = motor.getConfigurator().apply(currentConfig.MotionMagic, 0.05);
-            if (status.isOK()) {
-                lastAppliedMmAcceleration = newAccel;
-            } else {
-                LOGGER.log(Level.WARNING, "Failed to apply MotionMagic config: " + status);
-            }
-        }
+        queueMotionMagicConfigUpdate(lastRequestedMmCruiseVelocity, newAccel);
 
         motor.setControl(mmVelocityControl.withVelocity(velocity).withSlot(slot.getNum()));
     }
@@ -487,6 +472,38 @@ public class MotorIOTalonFX implements MotorIO {
     @Override
     public void setEncoderPosition(Angle position) {
         motor.setPosition(position);
+    }
+
+    private void queueMotionMagicConfigUpdate(double cruiseVelocity, double acceleration) {
+        if (cruiseVelocity == lastRequestedMmCruiseVelocity
+                && acceleration == lastRequestedMmAcceleration) {
+            return;
+        }
+
+        lastRequestedMmCruiseVelocity = cruiseVelocity;
+        lastRequestedMmAcceleration = acceleration;
+        currentConfig.MotionMagic.MotionMagicCruiseVelocity = cruiseVelocity;
+        currentConfig.MotionMagic.MotionMagicAcceleration = acceleration;
+
+        MotionMagicConfigs mmConfig = new MotionMagicConfigs();
+        mmConfig.MotionMagicCruiseVelocity = cruiseVelocity;
+        mmConfig.MotionMagicAcceleration = acceleration;
+
+        updateThread
+                .ctreCheckErrorAndRetry(() -> motor.getConfigurator().apply(mmConfig, 0.05))
+                .thenRun(
+                        () -> {
+                            lastAppliedMmCruiseVelocity = cruiseVelocity;
+                            lastAppliedMmAcceleration = acceleration;
+                        })
+                .exceptionally(
+                        ex -> {
+                            LOGGER.log(
+                                    Level.WARNING,
+                                    "Failed to apply MotionMagic config asynchronously",
+                                    ex);
+                            return null;
+                        });
     }
 
     private void setPIDSlot0(PID pid) {

--- a/src/main/java/frc/lib/io/motor/MotorIOTalonFX.java
+++ b/src/main/java/frc/lib/io/motor/MotorIOTalonFX.java
@@ -91,7 +91,7 @@ public class MotorIOTalonFX implements MotorIO {
     private volatile TalonFXConfiguration currentConfig;
     protected volatile Angle goalPosition = Rotations.of(0.0);
 
-    // Caches for last-applied dynamic Motion Magic parameters (NaN = never applied)
+    // Caches for last-applied Motion Magic parameters (NaN = never applied)
     private double lastAppliedMmCruiseVelocity = Double.NaN;
     private double lastAppliedMmAcceleration = Double.NaN;
 
@@ -399,9 +399,9 @@ public class MotorIOTalonFX implements MotorIO {
     }
 
     /**
-     * Runs the motor to a specific position using a Motion Magic request with dynamic cruise
-     * velocity and acceleration. Config is applied synchronously only when the values change to
-     * avoid unnecessary CAN bus traffic.
+     * Runs the motor to a specific position using a Motion Magic request with cruise velocity and
+     * acceleration. Config is applied synchronously only when the values change to avoid
+     * unnecessary CAN bus traffic.
      *
      * @param position Target position.
      * @param slot PID slot index.

--- a/src/main/java/frc/lib/io/motor/MotorIOTalonFX.java
+++ b/src/main/java/frc/lib/io/motor/MotorIOTalonFX.java
@@ -23,6 +23,7 @@ import com.ctre.phoenix6.BaseStatusSignal;
 import com.ctre.phoenix6.CANBus;
 import com.ctre.phoenix6.StatusSignal;
 import com.ctre.phoenix6.configs.TalonFXConfiguration;
+import com.ctre.phoenix6.configs.MotionMagicConfigs;
 import com.ctre.phoenix6.controls.*;
 import com.ctre.phoenix6.hardware.TalonFX;
 import com.ctre.phoenix6.signals.MotorAlignmentValue;
@@ -417,9 +418,10 @@ public class MotorIOTalonFX implements MotorIO {
         double newAccel = acceleration.in(RotationsPerSecondPerSecond);
 
         if (newCruise != lastAppliedMmCruiseVelocity || newAccel != lastAppliedMmAcceleration) {
-            currentConfig.MotionMagic.MotionMagicCruiseVelocity = newCruise;
-            currentConfig.MotionMagic.MotionMagicAcceleration = newAccel;
-            var status = motor.getConfigurator().apply(currentConfig.MotionMagic, 0.05);
+            MotionMagicConfigs mmConfig = new MotionMagicConfigs();
+            mmConfig.MotionMagicCruiseVelocity = newCruise;
+            mmConfig.MotionMagicAcceleration = newAccel;
+            var status = motor.getConfigurator().apply(mmConfig, 0.05);
             if (status.isOK()) {
                 lastAppliedMmCruiseVelocity = newCruise;
                 lastAppliedMmAcceleration = newAccel;

--- a/src/main/java/frc/lib/io/motor/MotorIOTalonFX.java
+++ b/src/main/java/frc/lib/io/motor/MotorIOTalonFX.java
@@ -22,8 +22,8 @@ import static edu.wpi.first.units.Units.RotationsPerSecondPerSecond;
 import com.ctre.phoenix6.BaseStatusSignal;
 import com.ctre.phoenix6.CANBus;
 import com.ctre.phoenix6.StatusSignal;
-import com.ctre.phoenix6.configs.TalonFXConfiguration;
 import com.ctre.phoenix6.configs.MotionMagicConfigs;
+import com.ctre.phoenix6.configs.TalonFXConfiguration;
 import com.ctre.phoenix6.controls.*;
 import com.ctre.phoenix6.hardware.TalonFX;
 import com.ctre.phoenix6.signals.MotorAlignmentValue;
@@ -450,17 +450,11 @@ public class MotorIOTalonFX implements MotorIO {
      * Runs the motor at a target velocity.
      *
      * @param velocity Desired velocity.
-     * @param acceleration Max acceleration.
      * @param slot PID slot index.
      */
     @Override
-    public void runVelocity(
-            AngularVelocity velocity, AngularAcceleration acceleration, PIDSlot slot) {
-        motor.setControl(
-                velocityControl
-                        .withVelocity(velocity)
-                        .withAcceleration(acceleration)
-                        .withSlot(slot.getNum()));
+    public void runVelocity(AngularVelocity velocity, PIDSlot slot) {
+        motor.setControl(velocityControl.withVelocity(velocity).withSlot(slot.getNum()));
     }
 
     /**
@@ -469,17 +463,13 @@ public class MotorIOTalonFX implements MotorIO {
      * only when the acceleration value changes to avoid unnecessary CAN bus traffic.
      *
      * @param velocity Desired velocity.
-     * @param acceleration Max feed-forward acceleration.
+     * @param acceleration Motion Magic acceleration used to ramp to target velocity.
      * @param slot PID slot index.
-     * @param motionMagicAcceleration Motion Magic acceleration used to ramp to target velocity.
      */
     @Override
     public void runVelocity(
-            AngularVelocity velocity,
-            AngularAcceleration acceleration,
-            PIDSlot slot,
-            AngularAcceleration motionMagicAcceleration) {
-        double newAccel = motionMagicAcceleration.in(RotationsPerSecondPerSecond);
+            AngularVelocity velocity, AngularAcceleration acceleration, PIDSlot slot) {
+        double newAccel = acceleration.in(RotationsPerSecondPerSecond);
 
         if (newAccel != lastAppliedMmAcceleration) {
             currentConfig.MotionMagic.MotionMagicAcceleration = newAccel;
@@ -491,11 +481,7 @@ public class MotorIOTalonFX implements MotorIO {
             }
         }
 
-        motor.setControl(
-                mmVelocityControl
-                        .withVelocity(velocity)
-                        .withAcceleration(acceleration)
-                        .withSlot(slot.getNum()));
+        motor.setControl(mmVelocityControl.withVelocity(velocity).withSlot(slot.getNum()));
     }
 
     @Override

--- a/src/main/java/frc/lib/io/motor/MotorIOTalonFX.java
+++ b/src/main/java/frc/lib/io/motor/MotorIOTalonFX.java
@@ -79,6 +79,8 @@ public class MotorIOTalonFX implements MotorIO {
     protected final PositionTorqueCurrentFOC unprofiledPositionControl =
             new PositionTorqueCurrentFOC(0);
     protected final VelocityTorqueCurrentFOC velocityControl = new VelocityTorqueCurrentFOC(0);
+    protected final MotionMagicVelocityTorqueCurrentFOC mmVelocityControl =
+            new MotionMagicVelocityTorqueCurrentFOC(0);
 
     private final CANUpdateThread updateThread = new CANUpdateThread();
     private final Alert[] followerOnWrongBusAlert;
@@ -87,6 +89,10 @@ public class MotorIOTalonFX implements MotorIO {
 
     private volatile TalonFXConfiguration currentConfig;
     protected volatile Angle goalPosition = Rotations.of(0.0);
+
+    // Caches for last-applied dynamic Motion Magic parameters (NaN = never applied)
+    private double lastAppliedMmCruiseVelocity = Double.NaN;
+    private double lastAppliedMmAcceleration = Double.NaN;
 
     /**
      * Constructs and initializes a TalonFX motor.
@@ -392,8 +398,9 @@ public class MotorIOTalonFX implements MotorIO {
     }
 
     /**
-     * Runs the motor to a specific position with dynamic Motion Magic cruise velocity and
-     * acceleration. Flashes an updated TalonFX configuration before issuing the control request.
+     * Runs the motor to a specific position using a Motion Magic request with dynamic cruise
+     * velocity and acceleration. Config is applied synchronously only when the values change to
+     * avoid unnecessary CAN bus traffic.
      *
      * @param position Target position.
      * @param slot PID slot index.
@@ -406,18 +413,20 @@ public class MotorIOTalonFX implements MotorIO {
             PIDSlot slot,
             AngularVelocity cruiseVelocity,
             AngularAcceleration acceleration) {
-        currentConfig.MotionMagic.MotionMagicCruiseVelocity = cruiseVelocity.in(RotationsPerSecond);
-        currentConfig.MotionMagic.MotionMagicAcceleration =
-                acceleration.in(RotationsPerSecondPerSecond);
+        double newCruise = cruiseVelocity.in(RotationsPerSecond);
+        double newAccel = acceleration.in(RotationsPerSecondPerSecond);
 
-        updateThread
-                .ctreCheckErrorAndRetry(
-                        () -> motor.getConfigurator().apply(currentConfig.MotionMagic))
-                .exceptionally(
-                        ex -> {
-                            LOGGER.log(Level.SEVERE, ex.toString(), ex);
-                            return null;
-                        });
+        if (newCruise != lastAppliedMmCruiseVelocity || newAccel != lastAppliedMmAcceleration) {
+            currentConfig.MotionMagic.MotionMagicCruiseVelocity = newCruise;
+            currentConfig.MotionMagic.MotionMagicAcceleration = newAccel;
+            var status = motor.getConfigurator().apply(currentConfig.MotionMagic, 0.05);
+            if (status.isOK()) {
+                lastAppliedMmCruiseVelocity = newCruise;
+                lastAppliedMmAcceleration = newAccel;
+            } else {
+                LOGGER.log(Level.WARNING, "Failed to apply MotionMagic config: " + status);
+            }
+        }
 
         this.goalPosition = position;
         motor.setControl(positionControl.withPosition(position).withSlot(slot.getNum()));
@@ -453,37 +462,35 @@ public class MotorIOTalonFX implements MotorIO {
     }
 
     /**
-     * Runs the motor at a target velocity with dynamic Motion Magic cruise velocity and
-     * acceleration. Flashes an updated TalonFX configuration before issuing the control request.
+     * Runs the motor at a target velocity using a Motion Magic velocity request that ramps to the
+     * target velocity using the provided Motion Magic acceleration. Config is applied synchronously
+     * only when the acceleration value changes to avoid unnecessary CAN bus traffic.
      *
      * @param velocity Desired velocity.
-     * @param acceleration Max acceleration.
+     * @param acceleration Max feed-forward acceleration.
      * @param slot PID slot index.
-     * @param cruiseVelocity Motion Magic cruise velocity.
-     * @param motionMagicAcceleration Motion Magic acceleration.
+     * @param motionMagicAcceleration Motion Magic acceleration used to ramp to target velocity.
      */
     @Override
     public void runVelocity(
             AngularVelocity velocity,
             AngularAcceleration acceleration,
             PIDSlot slot,
-            AngularVelocity cruiseVelocity,
             AngularAcceleration motionMagicAcceleration) {
-        currentConfig.MotionMagic.MotionMagicCruiseVelocity = cruiseVelocity.in(RotationsPerSecond);
-        currentConfig.MotionMagic.MotionMagicAcceleration =
-                motionMagicAcceleration.in(RotationsPerSecondPerSecond);
+        double newAccel = motionMagicAcceleration.in(RotationsPerSecondPerSecond);
 
-        updateThread
-                .ctreCheckErrorAndRetry(
-                        () -> motor.getConfigurator().apply(currentConfig.MotionMagic))
-                .exceptionally(
-                        ex -> {
-                            LOGGER.log(Level.SEVERE, ex.toString(), ex);
-                            return null;
-                        });
+        if (newAccel != lastAppliedMmAcceleration) {
+            currentConfig.MotionMagic.MotionMagicAcceleration = newAccel;
+            var status = motor.getConfigurator().apply(currentConfig.MotionMagic, 0.05);
+            if (status.isOK()) {
+                lastAppliedMmAcceleration = newAccel;
+            } else {
+                LOGGER.log(Level.WARNING, "Failed to apply MotionMagic config: " + status);
+            }
+        }
 
         motor.setControl(
-                velocityControl
+                mmVelocityControl
                         .withVelocity(velocity)
                         .withAcceleration(acceleration)
                         .withSlot(slot.getNum()));

--- a/src/main/java/frc/lib/io/motor/MotorIOTalonFX.java
+++ b/src/main/java/frc/lib/io/motor/MotorIOTalonFX.java
@@ -17,6 +17,7 @@ package frc.lib.io.motor;
 
 import static edu.wpi.first.units.Units.Rotations;
 import static edu.wpi.first.units.Units.RotationsPerSecond;
+import static edu.wpi.first.units.Units.RotationsPerSecondPerSecond;
 
 import com.ctre.phoenix6.BaseStatusSignal;
 import com.ctre.phoenix6.CANBus;
@@ -391,6 +392,38 @@ public class MotorIOTalonFX implements MotorIO {
     }
 
     /**
+     * Runs the motor to a specific position with dynamic Motion Magic cruise velocity and
+     * acceleration. Flashes an updated TalonFX configuration before issuing the control request.
+     *
+     * @param position Target position.
+     * @param slot PID slot index.
+     * @param cruiseVelocity Motion Magic cruise velocity.
+     * @param acceleration Motion Magic acceleration.
+     */
+    @Override
+    public void runPosition(
+            Angle position,
+            PIDSlot slot,
+            AngularVelocity cruiseVelocity,
+            AngularAcceleration acceleration) {
+        currentConfig.MotionMagic.MotionMagicCruiseVelocity = cruiseVelocity.in(RotationsPerSecond);
+        currentConfig.MotionMagic.MotionMagicAcceleration =
+                acceleration.in(RotationsPerSecondPerSecond);
+
+        updateThread
+                .ctreCheckErrorAndRetry(
+                        () -> motor.getConfigurator().apply(currentConfig.MotionMagic))
+                .exceptionally(
+                        ex -> {
+                            LOGGER.log(Level.SEVERE, ex.toString(), ex);
+                            return null;
+                        });
+
+        this.goalPosition = position;
+        motor.setControl(positionControl.withPosition(position).withSlot(slot.getNum()));
+    }
+
+    /**
      * Runs the motor to a specific position without a motion profile.
      *
      * @param position Target position.
@@ -412,6 +445,43 @@ public class MotorIOTalonFX implements MotorIO {
     @Override
     public void runVelocity(
             AngularVelocity velocity, AngularAcceleration acceleration, PIDSlot slot) {
+        motor.setControl(
+                velocityControl
+                        .withVelocity(velocity)
+                        .withAcceleration(acceleration)
+                        .withSlot(slot.getNum()));
+    }
+
+    /**
+     * Runs the motor at a target velocity with dynamic Motion Magic cruise velocity and
+     * acceleration. Flashes an updated TalonFX configuration before issuing the control request.
+     *
+     * @param velocity Desired velocity.
+     * @param acceleration Max acceleration.
+     * @param slot PID slot index.
+     * @param cruiseVelocity Motion Magic cruise velocity.
+     * @param motionMagicAcceleration Motion Magic acceleration.
+     */
+    @Override
+    public void runVelocity(
+            AngularVelocity velocity,
+            AngularAcceleration acceleration,
+            PIDSlot slot,
+            AngularVelocity cruiseVelocity,
+            AngularAcceleration motionMagicAcceleration) {
+        currentConfig.MotionMagic.MotionMagicCruiseVelocity = cruiseVelocity.in(RotationsPerSecond);
+        currentConfig.MotionMagic.MotionMagicAcceleration =
+                motionMagicAcceleration.in(RotationsPerSecondPerSecond);
+
+        updateThread
+                .ctreCheckErrorAndRetry(
+                        () -> motor.getConfigurator().apply(currentConfig.MotionMagic))
+                .exceptionally(
+                        ex -> {
+                            LOGGER.log(Level.SEVERE, ex.toString(), ex);
+                            return null;
+                        });
+
         motor.setControl(
                 velocityControl
                         .withVelocity(velocity)

--- a/src/main/java/frc/lib/mechanisms/Mechanism.java
+++ b/src/main/java/frc/lib/mechanisms/Mechanism.java
@@ -248,6 +248,23 @@ public abstract class Mechanism<T extends MotorIO> {
     }
 
     /**
+     * Runs the mechanism to a specific position with dynamic Motion Magic cruise velocity and
+     * acceleration.
+     *
+     * @param position Target position.
+     * @param slot PID slot index.
+     * @param cruiseVelocity Motion Magic cruise velocity.
+     * @param acceleration Motion Magic acceleration.
+     */
+    public void runPosition(
+            Angle position,
+            PIDSlot slot,
+            AngularVelocity cruiseVelocity,
+            AngularAcceleration acceleration) {
+        io.runPosition(position, slot, cruiseVelocity, acceleration);
+    }
+
+    /**
      * Runs the mechanism to a specific position without a motion profile.
      *
      * @param position Target position.
@@ -267,6 +284,25 @@ public abstract class Mechanism<T extends MotorIO> {
     public void runVelocity(
             AngularVelocity velocity, AngularAcceleration acceleration, PIDSlot slot) {
         io.runVelocity(velocity, acceleration, slot);
+    }
+
+    /**
+     * Runs the mechanism at a target velocity with dynamic Motion Magic cruise velocity and
+     * acceleration.
+     *
+     * @param velocity Desired velocity.
+     * @param acceleration Max acceleration.
+     * @param slot PID slot index.
+     * @param cruiseVelocity Motion Magic cruise velocity.
+     * @param motionMagicAcceleration Motion Magic acceleration.
+     */
+    public void runVelocity(
+            AngularVelocity velocity,
+            AngularAcceleration acceleration,
+            PIDSlot slot,
+            AngularVelocity cruiseVelocity,
+            AngularAcceleration motionMagicAcceleration) {
+        io.runVelocity(velocity, acceleration, slot, cruiseVelocity, motionMagicAcceleration);
     }
 
     /**
@@ -380,6 +416,32 @@ public abstract class Mechanism<T extends MotorIO> {
     }
 
     /**
+     * Runs the mechanism to a target linear position with dynamic Motion Magic cruise velocity and
+     * acceleration. Cruise velocity and acceleration are provided in linear units and converted to
+     * angular units using the configured radius.
+     *
+     * @param position Desired linear position
+     * @param slot PID slot to use
+     * @param cruiseVelocity Motion Magic cruise velocity in linear units
+     * @param acceleration Motion Magic acceleration in linear units
+     * @throws IllegalStateException if {@link #withRadius} was never called
+     */
+    public void runLinearPosition(
+            Distance position,
+            PIDSlot slot,
+            LinearVelocity cruiseVelocity,
+            LinearAcceleration acceleration) {
+        requireRadius();
+        Angle angle = Radians.of(position.in(Meters) / radiusMeters);
+        AngularVelocity angularCruiseVelocity =
+                RadiansPerSecond.of(cruiseVelocity.in(MetersPerSecond) / radiusMeters);
+        AngularAcceleration angularAcceleration =
+                RadiansPerSecondPerSecond.of(
+                        acceleration.in(MetersPerSecondPerSecond) / radiusMeters);
+        runPosition(angle, slot, angularCruiseVelocity, angularAcceleration);
+    }
+
+    /**
      * Runs the mechanism to a target linear position without a motion profile.
      *
      * @param position Desired linear position
@@ -409,6 +471,43 @@ public abstract class Mechanism<T extends MotorIO> {
                 RadiansPerSecondPerSecond.of(
                         acceleration.in(MetersPerSecondPerSecond) / radiusMeters);
         runVelocity(angularVelocity, angularAcceleration, slot);
+    }
+
+    /**
+     * Runs the mechanism at a target linear velocity with dynamic Motion Magic cruise velocity and
+     * acceleration. All parameters are provided in linear units and converted to angular units
+     * using the configured radius.
+     *
+     * @param velocity Desired linear velocity
+     * @param acceleration Maximum linear acceleration
+     * @param slot PID slot to use
+     * @param cruiseVelocity Motion Magic cruise velocity in linear units
+     * @param motionMagicAcceleration Motion Magic acceleration in linear units
+     * @throws IllegalStateException if {@link #withRadius} was never called
+     */
+    public void runLinearVelocity(
+            LinearVelocity velocity,
+            LinearAcceleration acceleration,
+            PIDSlot slot,
+            LinearVelocity cruiseVelocity,
+            LinearAcceleration motionMagicAcceleration) {
+        requireRadius();
+        AngularVelocity angularVelocity =
+                RadiansPerSecond.of(velocity.in(MetersPerSecond) / radiusMeters);
+        AngularAcceleration angularAcceleration =
+                RadiansPerSecondPerSecond.of(
+                        acceleration.in(MetersPerSecondPerSecond) / radiusMeters);
+        AngularVelocity angularCruiseVelocity =
+                RadiansPerSecond.of(cruiseVelocity.in(MetersPerSecond) / radiusMeters);
+        AngularAcceleration angularMotionMagicAcceleration =
+                RadiansPerSecondPerSecond.of(
+                        motionMagicAcceleration.in(MetersPerSecondPerSecond) / radiusMeters);
+        runVelocity(
+                angularVelocity,
+                angularAcceleration,
+                slot,
+                angularCruiseVelocity,
+                angularMotionMagicAcceleration);
     }
 
     /**

--- a/src/main/java/frc/lib/mechanisms/Mechanism.java
+++ b/src/main/java/frc/lib/mechanisms/Mechanism.java
@@ -248,8 +248,7 @@ public abstract class Mechanism<T extends MotorIO> {
     }
 
     /**
-     * Runs the mechanism to a specific position with dynamic Motion Magic cruise velocity and
-     * acceleration.
+     * Runs the mechanism to a specific position with Motion Magic cruise velocity and acceleration.
      *
      * @param position Target position.
      * @param slot PID slot index.
@@ -408,7 +407,7 @@ public abstract class Mechanism<T extends MotorIO> {
     }
 
     /**
-     * Runs the mechanism to a target linear position with dynamic Motion Magic cruise velocity and
+     * Runs the mechanism to a target linear position with Motion Magic cruise velocity and
      * acceleration. Cruise velocity and acceleration are provided in linear units and converted to
      * angular units using the configured radius.
      *

--- a/src/main/java/frc/lib/mechanisms/Mechanism.java
+++ b/src/main/java/frc/lib/mechanisms/Mechanism.java
@@ -287,22 +287,20 @@ public abstract class Mechanism<T extends MotorIO> {
     }
 
     /**
-     * Runs the mechanism at a target velocity with dynamic Motion Magic cruise velocity and
-     * acceleration.
+     * Runs the mechanism at a target velocity using a Motion Magic velocity request that ramps to
+     * the target velocity using the provided Motion Magic acceleration.
      *
      * @param velocity Desired velocity.
-     * @param acceleration Max acceleration.
+     * @param acceleration Max feed-forward acceleration.
      * @param slot PID slot index.
-     * @param cruiseVelocity Motion Magic cruise velocity.
-     * @param motionMagicAcceleration Motion Magic acceleration.
+     * @param motionMagicAcceleration Motion Magic acceleration used to ramp to target velocity.
      */
     public void runVelocity(
             AngularVelocity velocity,
             AngularAcceleration acceleration,
             PIDSlot slot,
-            AngularVelocity cruiseVelocity,
             AngularAcceleration motionMagicAcceleration) {
-        io.runVelocity(velocity, acceleration, slot, cruiseVelocity, motionMagicAcceleration);
+        io.runVelocity(velocity, acceleration, slot, motionMagicAcceleration);
     }
 
     /**
@@ -474,22 +472,21 @@ public abstract class Mechanism<T extends MotorIO> {
     }
 
     /**
-     * Runs the mechanism at a target linear velocity with dynamic Motion Magic cruise velocity and
-     * acceleration. All parameters are provided in linear units and converted to angular units
-     * using the configured radius.
+     * Runs the mechanism at a target linear velocity using a Motion Magic velocity request that
+     * ramps to the target velocity using the provided Motion Magic acceleration. All parameters are
+     * provided in linear units and converted to angular units using the configured radius.
      *
      * @param velocity Desired linear velocity
-     * @param acceleration Maximum linear acceleration
+     * @param acceleration Maximum linear feed-forward acceleration
      * @param slot PID slot to use
-     * @param cruiseVelocity Motion Magic cruise velocity in linear units
-     * @param motionMagicAcceleration Motion Magic acceleration in linear units
+     * @param motionMagicAcceleration Motion Magic acceleration in linear units used to ramp to
+     *     target velocity
      * @throws IllegalStateException if {@link #withRadius} was never called
      */
     public void runLinearVelocity(
             LinearVelocity velocity,
             LinearAcceleration acceleration,
             PIDSlot slot,
-            LinearVelocity cruiseVelocity,
             LinearAcceleration motionMagicAcceleration) {
         requireRadius();
         AngularVelocity angularVelocity =
@@ -497,17 +494,10 @@ public abstract class Mechanism<T extends MotorIO> {
         AngularAcceleration angularAcceleration =
                 RadiansPerSecondPerSecond.of(
                         acceleration.in(MetersPerSecondPerSecond) / radiusMeters);
-        AngularVelocity angularCruiseVelocity =
-                RadiansPerSecond.of(cruiseVelocity.in(MetersPerSecond) / radiusMeters);
         AngularAcceleration angularMotionMagicAcceleration =
                 RadiansPerSecondPerSecond.of(
                         motionMagicAcceleration.in(MetersPerSecondPerSecond) / radiusMeters);
-        runVelocity(
-                angularVelocity,
-                angularAcceleration,
-                slot,
-                angularCruiseVelocity,
-                angularMotionMagicAcceleration);
+        runVelocity(angularVelocity, angularAcceleration, slot, angularMotionMagicAcceleration);
     }
 
     /**

--- a/src/main/java/frc/lib/mechanisms/Mechanism.java
+++ b/src/main/java/frc/lib/mechanisms/Mechanism.java
@@ -278,12 +278,10 @@ public abstract class Mechanism<T extends MotorIO> {
      * Runs the mechanism at a target velocity.
      *
      * @param velocity Desired velocity.
-     * @param acceleration Max acceleration.
      * @param slot PID slot index.
      */
-    public void runVelocity(
-            AngularVelocity velocity, AngularAcceleration acceleration, PIDSlot slot) {
-        io.runVelocity(velocity, acceleration, slot);
+    public void runVelocity(AngularVelocity velocity, PIDSlot slot) {
+        io.runVelocity(velocity, slot);
     }
 
     /**
@@ -291,16 +289,12 @@ public abstract class Mechanism<T extends MotorIO> {
      * the target velocity using the provided Motion Magic acceleration.
      *
      * @param velocity Desired velocity.
-     * @param acceleration Max feed-forward acceleration.
+     * @param acceleration Motion Magic acceleration used to ramp to target velocity.
      * @param slot PID slot index.
-     * @param motionMagicAcceleration Motion Magic acceleration used to ramp to target velocity.
      */
     public void runVelocity(
-            AngularVelocity velocity,
-            AngularAcceleration acceleration,
-            PIDSlot slot,
-            AngularAcceleration motionMagicAcceleration) {
-        io.runVelocity(velocity, acceleration, slot, motionMagicAcceleration);
+            AngularVelocity velocity, AngularAcceleration acceleration, PIDSlot slot) {
+        io.runVelocity(velocity, acceleration, slot);
     }
 
     /**
@@ -456,19 +450,14 @@ public abstract class Mechanism<T extends MotorIO> {
      * Runs the mechanism at a target linear velocity with acceleration limiting.
      *
      * @param velocity Desired linear velocity
-     * @param acceleration Maximum linear acceleration
      * @param slot PID slot to use
      * @throws IllegalStateException if {@link #withRadius} was never called
      */
-    public void runLinearVelocity(
-            LinearVelocity velocity, LinearAcceleration acceleration, PIDSlot slot) {
+    public void runLinearVelocity(LinearVelocity velocity, PIDSlot slot) {
         requireRadius();
         AngularVelocity angularVelocity =
                 RadiansPerSecond.of(velocity.in(MetersPerSecond) / radiusMeters);
-        AngularAcceleration angularAcceleration =
-                RadiansPerSecondPerSecond.of(
-                        acceleration.in(MetersPerSecondPerSecond) / radiusMeters);
-        runVelocity(angularVelocity, angularAcceleration, slot);
+        runVelocity(angularVelocity, slot);
     }
 
     /**
@@ -477,27 +466,19 @@ public abstract class Mechanism<T extends MotorIO> {
      * provided in linear units and converted to angular units using the configured radius.
      *
      * @param velocity Desired linear velocity
-     * @param acceleration Maximum linear feed-forward acceleration
      * @param slot PID slot to use
-     * @param motionMagicAcceleration Motion Magic acceleration in linear units used to ramp to
-     *     target velocity
+     * @param acceleration Motion Magic acceleration in linear units used to ramp to target velocity
      * @throws IllegalStateException if {@link #withRadius} was never called
      */
     public void runLinearVelocity(
-            LinearVelocity velocity,
-            LinearAcceleration acceleration,
-            PIDSlot slot,
-            LinearAcceleration motionMagicAcceleration) {
+            LinearVelocity velocity, PIDSlot slot, LinearAcceleration acceleration) {
         requireRadius();
         AngularVelocity angularVelocity =
                 RadiansPerSecond.of(velocity.in(MetersPerSecond) / radiusMeters);
-        AngularAcceleration angularAcceleration =
+        AngularAcceleration angularacceleration =
                 RadiansPerSecondPerSecond.of(
                         acceleration.in(MetersPerSecondPerSecond) / radiusMeters);
-        AngularAcceleration angularMotionMagicAcceleration =
-                RadiansPerSecondPerSecond.of(
-                        motionMagicAcceleration.in(MetersPerSecondPerSecond) / radiusMeters);
-        runVelocity(angularVelocity, angularAcceleration, slot, angularMotionMagicAcceleration);
+        runVelocity(angularVelocity, angularacceleration, slot);
     }
 
     /**

--- a/src/main/java/frc/lib/mechanisms/linear/LinearMechanism.java
+++ b/src/main/java/frc/lib/mechanisms/linear/LinearMechanism.java
@@ -84,7 +84,7 @@ public abstract class LinearMechanism<T extends MotorIO> extends Mechanism<T> {
 
     /**
      * Gets the current goal linear position of the mechanism, as set by the last position control
-     * request. Returns {@link Distance#zero()} if not in position control mode.
+     * request. Returns 0 m if not in position control mode.
      *
      * @return Goal linear position
      */

--- a/src/main/java/frc/lib/mechanisms/linear/LinearMechanism.java
+++ b/src/main/java/frc/lib/mechanisms/linear/LinearMechanism.java
@@ -82,6 +82,16 @@ public abstract class LinearMechanism<T extends MotorIO> extends Mechanism<T> {
         return Optional.of(toDistance(inputs.goalPosition));
     }
 
+    /**
+     * Gets the current goal linear position of the mechanism, as set by the last position control
+     * request. Returns {@link Distance#zero()} if not in position control mode.
+     *
+     * @return Goal linear position
+     */
+    public Distance getGoalLinearPosition() {
+        return getGoalDistance().orElse(Meters.zero());
+    }
+
     // Checks if mechanism is near a goal position within a specified tolerance
     public boolean nearGoal(Distance goalPosition, Distance tolerance) {
         return MathUtil.isNear(

--- a/src/main/java/frc/robot/subsystems/indexer/IndexerSuperstructure.java
+++ b/src/main/java/frc/robot/subsystems/indexer/IndexerSuperstructure.java
@@ -14,13 +14,9 @@
  */
 package frc.robot.subsystems.indexer;
 
-import static edu.wpi.first.units.Units.Meters;
-import static edu.wpi.first.units.Units.MetersPerSecondPerSecond;
-import static edu.wpi.first.units.Units.RadiansPerSecondPerSecond;
 import static edu.wpi.first.units.Units.RotationsPerSecond;
 
 import edu.wpi.first.units.measure.AngularVelocity;
-import edu.wpi.first.units.measure.LinearAcceleration;
 import edu.wpi.first.units.measure.LinearVelocity;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Command.InterruptionBehavior;
@@ -126,9 +122,8 @@ public class IndexerSuperstructure extends SubsystemBase {
     }
 
     private void runVelocity(AngularVelocity floorVelocity, AngularVelocity centeringVelocity) {
-        floorIO.runVelocity(floorVelocity, IndexerFloorConstants.MAX_ACCELERATION, PIDSlot.SLOT_0);
-        centerIO.runVelocity(
-                centeringVelocity, IndexerCenterConstants.MAX_ACCELERATION, PIDSlot.SLOT_0);
+        floorIO.runVelocity(floorVelocity, PIDSlot.SLOT_0);
+        centerIO.runVelocity(centeringVelocity, PIDSlot.SLOT_0);
     }
 
     /**
@@ -268,17 +263,8 @@ public class IndexerSuperstructure extends SubsystemBase {
      *     second)
      */
     public void setLinearVelocity(LinearVelocity floorVelocity, LinearVelocity centeringVelocity) {
-        // Convert the angular acceleration constants to linear acceleration using each wheel radius
-        LinearAcceleration floorLinearAccel =
-                MetersPerSecondPerSecond.of(
-                        IndexerFloorConstants.MAX_ACCELERATION.in(RadiansPerSecondPerSecond)
-                                * IndexerFloorConstants.RADIUS.in(Meters));
-        LinearAcceleration centerLinearAccel =
-                MetersPerSecondPerSecond.of(
-                        IndexerCenterConstants.MAX_ACCELERATION.in(RadiansPerSecondPerSecond)
-                                * IndexerCenterConstants.RADIUS.in(Meters));
-        floorIO.runLinearVelocity(floorVelocity, floorLinearAccel, PIDSlot.SLOT_0);
-        centerIO.runLinearVelocity(centeringVelocity, centerLinearAccel, PIDSlot.SLOT_0);
+        floorIO.runLinearVelocity(floorVelocity, PIDSlot.SLOT_0);
+        centerIO.runLinearVelocity(centeringVelocity, PIDSlot.SLOT_0);
     }
 
     /** Closes the indexer mechanism and releases resources. */

--- a/src/main/java/frc/robot/subsystems/intake/IntakeSuperstructure.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeSuperstructure.java
@@ -17,11 +17,7 @@ package frc.robot.subsystems.intake;
 import static edu.wpi.first.units.Units.*;
 
 import edu.wpi.first.math.MathUtil;
-import edu.wpi.first.math.trajectory.TrapezoidProfile;
-import edu.wpi.first.math.trajectory.TrapezoidProfile.Constraints;
-import edu.wpi.first.math.trajectory.TrapezoidProfile.State;
 import edu.wpi.first.units.measure.*;
-import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.*;
 
 import frc.lib.io.motor.MotorIO.PIDSlot;
@@ -57,39 +53,17 @@ public class IntakeSuperstructure extends SubsystemBase implements AutoCloseable
 
     private final LinearVelocity shuffleVelocity = MetersPerSecond.of(0.8);
 
-    private final TrapezoidProfile fastMotionProfiler =
-            new TrapezoidProfile(
-                    new Constraints(
-                            IntakeLinearConstants.CRUISE_VELOCITY.in(MetersPerSecond),
-                            IntakeLinearConstants.MAX_ACCELERATION.in(MetersPerSecondPerSecond)));
-
-    private TrapezoidProfile slowMotionProfiler =
-            new TrapezoidProfile(
-                    new Constraints(
-                            SLOW_MPS.get(),
-                            IntakeLinearConstants.MAX_ACCELERATION.in(MetersPerSecondPerSecond)));
-    private TrapezoidProfile shuffleMotionProfiler =
-            new TrapezoidProfile(
-                    new Constraints(
-                            shuffleVelocity.in(MetersPerSecond),
-                            IntakeLinearConstants.MAX_ACCELERATION.in(MetersPerSecondPerSecond)));
-
-    private State setpointState = new State(IntakeLinearConstants.MIN_DISTANCE.in(Meters), 0.0);
-
-    private State goalState = new State(IntakeLinearConstants.MIN_DISTANCE.in(Meters), 0.0);
-
-    private TrapezoidProfile activeProfiler = fastMotionProfiler;
-
-    private double lastTimestamp = Timer.getTimestamp();
-    private boolean runProfile = true;
-
     public IntakeSuperstructure(
             LinearMechanism<?> intakeLinearIO, FlywheelMechanism<?> intakeRollerIO) {
 
         this.intakeLinearIO = intakeLinearIO;
         this.intakeRollerIO = intakeRollerIO;
 
-        intakeLinearIO.runLinearPosition(IntakeLinearConstants.MIN_DISTANCE, PIDSlot.SLOT_0);
+        intakeLinearIO.runLinearPosition(
+                IntakeLinearConstants.MIN_DISTANCE,
+                PIDSlot.SLOT_0,
+                IntakeLinearConstants.CRUISE_VELOCITY,
+                IntakeLinearConstants.MAX_ACCELERATION);
 
         isExtended =
                 new LoggedTrigger(
@@ -129,40 +103,44 @@ public class IntakeSuperstructure extends SubsystemBase implements AutoCloseable
                                         IntakeLinearConstants.TOLERANCE.in(Meters)));
     }
 
-    private void resetSetpoint() {
-        double current = intakeLinearIO.getLinearPosition().in(Meters);
-        setpointState = new State(current, 0.0);
-    }
-
-    private TrapezoidProfile createProfiler(double maxVelocityMetersPerSecond) {
-        return new TrapezoidProfile(
-                new Constraints(
-                        maxVelocityMetersPerSecond,
-                        IntakeLinearConstants.MAX_ACCELERATION.in(MetersPerSecondPerSecond)));
-    }
-
-    private void startProfile(TrapezoidProfile profiler, double goalMeters) {
-        resetSetpoint();
-
-        goalState.position = goalMeters;
-        goalState.velocity = 0.0;
-
-        activeProfiler = profiler;
-    }
-
     /** Returns true if the intake roller is running and the intake is extended. */
     public boolean isIntaking() {
         return intakeRollerIO.getVelocity().in(RotationsPerSecond) > 1.0
                 && isExtended.getAsBoolean();
     }
 
-    private Command moveToPosition(TrapezoidProfile profiler, double goalMeters, String name) {
-        return this.runOnce(() -> startProfile(profiler, goalMeters)).withName(name);
+    /**
+     * Moves the intake to a goal distance using Motion Magic with the given cruise velocity and
+     * acceleration. The command completes immediately after issuing the control request — use
+     * {@link Commands#waitUntil} to block until the goal is reached.
+     */
+    private Command moveToPosition(
+            Distance goal,
+            LinearVelocity cruiseVelocity,
+            LinearAcceleration acceleration,
+            String name) {
+        Distance clampedGoal =
+                Meters.of(
+                        MathUtil.clamp(
+                                goal.in(Meters),
+                                IntakeLinearConstants.MIN_DISTANCE.in(Meters),
+                                IntakeLinearConstants.MAX_DISTANCE.in(Meters)));
+        return this.runOnce(
+                        () ->
+                                intakeLinearIO.runLinearPosition(
+                                        clampedGoal, PIDSlot.SLOT_0, cruiseVelocity, acceleration))
+                .withName(name);
     }
 
+    /**
+     * Moves the intake by a delta in inches using Motion Magic with the given cruise velocity and
+     * acceleration, optionally running the roller at a scaled speed, and waits until within
+     * toleranceMeters of the goal.
+     */
     private Command moveByInches(
             double inches,
-            TrapezoidProfile profiler,
+            LinearVelocity cruiseVelocity,
+            LinearAcceleration acceleration,
             boolean runRoller,
             double rollerScale,
             double toleranceMeters,
@@ -172,15 +150,16 @@ public class IntakeSuperstructure extends SubsystemBase implements AutoCloseable
                         this.runOnce(
                                 () -> {
                                     double current = intakeLinearIO.getLinearPosition().in(Meters);
-                                    double delta = Inches.of(inches).in(Meters);
-
-                                    double goal =
-                                            MathUtil.clamp(
-                                                    current + delta,
-                                                    IntakeLinearConstants.MIN_DISTANCE.in(Meters),
-                                                    IntakeLinearConstants.MAX_DISTANCE.in(Meters));
-
-                                    startProfile(profiler, goal);
+                                    Distance goal =
+                                            Meters.of(
+                                                    MathUtil.clamp(
+                                                            current + Inches.of(inches).in(Meters),
+                                                            IntakeLinearConstants.MIN_DISTANCE.in(
+                                                                    Meters),
+                                                            IntakeLinearConstants.MAX_DISTANCE.in(
+                                                                    Meters)));
+                                    intakeLinearIO.runLinearPosition(
+                                            goal, PIDSlot.SLOT_0, cruiseVelocity, acceleration);
                                 }),
                         runRoller
                                 ? runRoller(
@@ -191,15 +170,21 @@ public class IntakeSuperstructure extends SubsystemBase implements AutoCloseable
                         Commands.waitUntil(
                                 () ->
                                         MathUtil.isNear(
-                                                goalState.position,
+                                                intakeLinearIO.getGoalLinearPosition().in(Meters),
                                                 intakeLinearIO.getLinearPosition().in(Meters),
                                                 toleranceMeters)))
                 .withName(name);
     }
 
+    /**
+     * Moves the intake to an absolute position in inches using Motion Magic with the given cruise
+     * velocity and acceleration, optionally running the roller, and waits until within
+     * toleranceMeters of the goal.
+     */
     private Command moveToInches(
             double inches,
-            TrapezoidProfile profiler,
+            LinearVelocity cruiseVelocity,
+            LinearAcceleration acceleration,
             boolean runRoller,
             double rollerScale,
             double toleranceMeters,
@@ -208,13 +193,16 @@ public class IntakeSuperstructure extends SubsystemBase implements AutoCloseable
         return Commands.sequence(
                         this.runOnce(
                                 () -> {
-                                    double goal =
-                                            MathUtil.clamp(
-                                                    Inches.of(inches).in(Meters),
-                                                    IntakeLinearConstants.MIN_DISTANCE.in(Meters),
-                                                    IntakeLinearConstants.MAX_DISTANCE.in(Meters));
-
-                                    startProfile(profiler, goal);
+                                    Distance goal =
+                                            Meters.of(
+                                                    MathUtil.clamp(
+                                                            Inches.of(inches).in(Meters),
+                                                            IntakeLinearConstants.MIN_DISTANCE.in(
+                                                                    Meters),
+                                                            IntakeLinearConstants.MAX_DISTANCE.in(
+                                                                    Meters)));
+                                    intakeLinearIO.runLinearPosition(
+                                            goal, PIDSlot.SLOT_0, cruiseVelocity, acceleration);
                                 }),
                         runRoller
                                 ? runRoller(
@@ -225,7 +213,7 @@ public class IntakeSuperstructure extends SubsystemBase implements AutoCloseable
                         Commands.waitUntil(
                                 () ->
                                         MathUtil.isNear(
-                                                goalState.position,
+                                                intakeLinearIO.getGoalLinearPosition().in(Meters),
                                                 intakeLinearIO.getLinearPosition().in(Meters),
                                                 toleranceMeters)))
                 .withName(name);
@@ -260,8 +248,9 @@ public class IntakeSuperstructure extends SubsystemBase implements AutoCloseable
         return Commands.sequence(
                         runRoller(() -> RotationsPerSecond.of(ROLLER_INTAKE_RPS.get())),
                         moveToPosition(
-                                fastMotionProfiler,
-                                IntakeLinearConstants.MAX_DISTANCE.in(Meters),
+                                IntakeLinearConstants.MAX_DISTANCE,
+                                IntakeLinearConstants.CRUISE_VELOCITY,
+                                IntakeLinearConstants.MAX_ACCELERATION,
                                 "Extend Linear"))
                 .withName("Intake");
     }
@@ -271,8 +260,9 @@ public class IntakeSuperstructure extends SubsystemBase implements AutoCloseable
         return Commands.sequence(
                         runRoller(() -> RotationsPerSecond.of(ROLLER_AUTO_INTAKE_RPS.get())),
                         moveToPosition(
-                                fastMotionProfiler,
-                                IntakeLinearConstants.MAX_DISTANCE.in(Meters),
+                                IntakeLinearConstants.MAX_DISTANCE,
+                                IntakeLinearConstants.CRUISE_VELOCITY,
+                                IntakeLinearConstants.MAX_ACCELERATION,
                                 "Extend Linear"))
                 .withName("Auto Intake");
     }
@@ -281,8 +271,9 @@ public class IntakeSuperstructure extends SubsystemBase implements AutoCloseable
         return Commands.sequence(
                         runRoller(RotationsPerSecond::zero),
                         moveToPosition(
-                                fastMotionProfiler,
-                                IntakeLinearConstants.MAX_DISTANCE.in(Meters),
+                                IntakeLinearConstants.MAX_DISTANCE,
+                                IntakeLinearConstants.CRUISE_VELOCITY,
+                                IntakeLinearConstants.MAX_ACCELERATION,
                                 "Extend Linear"))
                 .withName("Extend Intake");
     }
@@ -291,9 +282,9 @@ public class IntakeSuperstructure extends SubsystemBase implements AutoCloseable
         return Commands.sequence(
                         runRoller(() -> RotationsPerSecond.of(ROLLER_INTAKE_RPS.get())),
                         moveToPosition(
-                                fastMotionProfiler,
-                                IntakeLinearConstants.MIN_DISTANCE.in(Meters)
-                                        + Inches.of(2.0).in(Meters),
+                                IntakeLinearConstants.MIN_DISTANCE.plus(Inches.of(2.0)),
+                                IntakeLinearConstants.CRUISE_VELOCITY,
+                                IntakeLinearConstants.MAX_ACCELERATION,
                                 "Retract Linear"),
                         Commands.waitUntil(isRetracted),
                         stopRoller())
@@ -302,14 +293,11 @@ public class IntakeSuperstructure extends SubsystemBase implements AutoCloseable
 
     public Command slowRetract(LinearVelocity retractSpeed) {
         return Commands.sequence(
-                Commands.runOnce(
-                        () ->
-                                slowMotionProfiler =
-                                        createProfiler(retractSpeed.in(MetersPerSecond))),
                 runRoller(() -> RotationsPerSecond.of(ROLLER_INTAKE_RPS.get()).times(0.6)),
                 moveToPosition(
-                        slowMotionProfiler,
-                        IntakeLinearConstants.MIN_DISTANCE.in(Meters) + Inches.of(2.0).in(Meters),
+                        IntakeLinearConstants.MIN_DISTANCE.plus(Inches.of(2.0)),
+                        retractSpeed,
+                        IntakeLinearConstants.MAX_ACCELERATION,
                         "Slow Retract"),
                 Commands.waitUntil(isRetracted),
                 stopRoller());
@@ -336,7 +324,8 @@ public class IntakeSuperstructure extends SubsystemBase implements AutoCloseable
                                 isCycleComplete),
                         moveByInches(
                                         -6,
-                                        shuffleMotionProfiler,
+                                        shuffleVelocity,
+                                        IntakeLinearConstants.MAX_ACCELERATION,
                                         true,
                                         0.6,
                                         Inches.of(0.5).in(Meters),
@@ -344,7 +333,8 @@ public class IntakeSuperstructure extends SubsystemBase implements AutoCloseable
                                 .withTimeout(0.5),
                         moveByInches(
                                         3.0,
-                                        shuffleMotionProfiler,
+                                        shuffleVelocity,
+                                        IntakeLinearConstants.MAX_ACCELERATION,
                                         false,
                                         0.0,
                                         Inches.of(0.5).in(Meters),
@@ -365,7 +355,8 @@ public class IntakeSuperstructure extends SubsystemBase implements AutoCloseable
                         // Ensure intake is retracted
                         moveToInches(
                                         IntakeLinearConstants.MIN_DISTANCE.in(Inches),
-                                        shuffleMotionProfiler,
+                                        shuffleVelocity,
+                                        IntakeLinearConstants.MAX_ACCELERATION,
                                         true,
                                         0.6,
                                         Inches.of(0.5).in(Meters),
@@ -373,7 +364,8 @@ public class IntakeSuperstructure extends SubsystemBase implements AutoCloseable
                                 .withTimeout(1),
                         moveByInches(
                                         3.15,
-                                        shuffleMotionProfiler,
+                                        shuffleVelocity,
+                                        IntakeLinearConstants.MAX_ACCELERATION,
                                         false,
                                         0.0,
                                         Inches.of(0.5).in(Meters),
@@ -389,39 +381,12 @@ public class IntakeSuperstructure extends SubsystemBase implements AutoCloseable
 
     public Command homeLinear() {
         return Commands.sequence(
-                        Commands.runOnce(() -> runProfile = false),
-                        this.runOnce(() -> intakeLinearIO.runDutyCycle(0.25, true)),
-                        this.idle())
-                .finallyDo(
-                        () -> {
-                            intakeLinearIO.setEncoderPosition(Rotations.of(3.7));
-                            runProfile = true;
-                        });
+                        this.runOnce(() -> intakeLinearIO.runDutyCycle(0.25, true)), this.idle())
+                .finallyDo(() -> intakeLinearIO.setEncoderPosition(Rotations.of(3.7)));
     }
 
     @Override
     public void periodic() {
-
-        if (SLOW_MPS.hasChanged(hashCode())) {
-            slowMotionProfiler =
-                    new TrapezoidProfile(
-                            new Constraints(
-                                    SLOW_MPS.get(),
-                                    IntakeLinearConstants.MAX_ACCELERATION.in(
-                                            MetersPerSecondPerSecond)));
-        }
-
-        double now = Timer.getTimestamp();
-        double delta = now - lastTimestamp;
-        lastTimestamp = now;
-
-        setpointState = activeProfiler.calculate(delta, setpointState, goalState);
-
-        if (runProfile) {
-            intakeLinearIO.runUnprofiledLinearPosition(
-                    Meters.of(setpointState.position), PIDSlot.SLOT_0);
-        }
-
         LoggerHelper.recordCurrentCommand(this.getName(), this);
         intakeLinearIO.periodic();
         intakeRollerIO.periodic();

--- a/src/main/java/frc/robot/subsystems/intake/IntakeSuperstructure.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeSuperstructure.java
@@ -220,12 +220,7 @@ public class IntakeSuperstructure extends SubsystemBase implements AutoCloseable
     }
 
     private Command runRoller(Supplier<AngularVelocity> angularVelocity) {
-        return this.runOnce(
-                        () ->
-                                intakeRollerIO.runVelocity(
-                                        angularVelocity.get(),
-                                        IntakeRollerConstants.MAX_ACCELERATION,
-                                        PIDSlot.SLOT_0))
+        return this.runOnce(() -> intakeRollerIO.runVelocity(angularVelocity.get(), PIDSlot.SLOT_0))
                 .withName("Run Roller");
     }
 
@@ -238,7 +233,6 @@ public class IntakeSuperstructure extends SubsystemBase implements AutoCloseable
                         () ->
                                 intakeRollerIO.runVelocity(
                                         RotationsPerSecond.of(ROLLER_EJECT_RPS.get()),
-                                        IntakeRollerConstants.MAX_ACCELERATION,
                                         PIDSlot.SLOT_0),
                         intakeRollerIO::runBrake)
                 .withName("Eject Roller");

--- a/src/main/java/frc/robot/subsystems/shooter/ShooterSuperstructure.java
+++ b/src/main/java/frc/robot/subsystems/shooter/ShooterSuperstructure.java
@@ -223,14 +223,8 @@ public class ShooterSuperstructure extends SubsystemBase implements AutoCloseabl
     }
 
     private void spinFlywheel(AngularVelocity velocity) {
-        leftFlywheelIO.runVelocity(
-                velocity.plus(getFlywheelTrim()),
-                FlywheelConstants.MAX_ACCELERATION,
-                PIDSlot.SLOT_0);
-        rightFlywheelIO.runVelocity(
-                velocity.plus(getFlywheelTrim()),
-                FlywheelConstants.MAX_ACCELERATION,
-                PIDSlot.SLOT_0);
+        leftFlywheelIO.runVelocity(velocity.plus(getFlywheelTrim()), PIDSlot.SLOT_0);
+        rightFlywheelIO.runVelocity(velocity.plus(getFlywheelTrim()), PIDSlot.SLOT_0);
     }
 
     private boolean isFlywheelAt(AngularVelocity velocity) {

--- a/src/main/java/frc/robot/subsystems/tower/Tower.java
+++ b/src/main/java/frc/robot/subsystems/tower/Tower.java
@@ -109,7 +109,7 @@ public class Tower extends SubsystemBase {
     }
 
     private void runVelocity(AngularVelocity velocity) {
-        io.runVelocity(velocity, TowerConstants.MAX_ACCELERATION, PIDSlot.SLOT_0);
+        io.runVelocity(velocity, PIDSlot.SLOT_0);
     }
 
     /**


### PR DESCRIPTION
This pull request adds support for running motors and mechanisms with dynamic Motion Magic cruise velocity and acceleration parameters, both in angular and linear units. The changes introduce new methods to the `MotorIO` interface and its `TalonFX` implementation, as well as the `Mechanism` class, allowing users to specify cruise velocity and acceleration at runtime for more flexible and precise control.

**Motion Magic Enhancements**

* Added new overloads to the `MotorIO` interface for `runPosition` and `runVelocity`, allowing the caller to specify cruise velocity and acceleration dynamically. [[1]](diffhunk://#diff-d5749314519f38b6cbf05c53b1e0a1ceeb169908cb4b179879579f181b8cf838R159-R173) [[2]](diffhunk://#diff-d5749314519f38b6cbf05c53b1e0a1ceeb169908cb4b179879579f181b8cf838R192-R208)
* Implemented these overloads in `MotorIOTalonFX`, updating the TalonFX configuration with the provided cruise velocity and acceleration before issuing the control command. [[1]](diffhunk://#diff-7d85ba1ab015f6e514c0ed63a374aa6ed4b725dc65133ce511a48b9333d03b65R394-R425) [[2]](diffhunk://#diff-7d85ba1ab015f6e514c0ed63a374aa6ed4b725dc65133ce511a48b9333d03b65R455-R491)
* Imported `RotationsPerSecondPerSecond` to support conversion for acceleration units in `MotorIOTalonFX`.

**Mechanism API Extensions**

* Added corresponding methods in the `Mechanism` class to expose the new dynamic Motion Magic controls for both position and velocity, delegating to the underlying `MotorIO` implementation. [[1]](diffhunk://#diff-d2e8adf374e82b768f0de7c44eae88deaf77586cadfe7c566352248e4caa079eR250-R266) [[2]](diffhunk://#diff-d2e8adf374e82b768f0de7c44eae88deaf77586cadfe7c566352248e4caa079eR289-R307)
* Introduced new methods in `Mechanism` to support running to a linear position or velocity with dynamic cruise velocity and acceleration, converting linear units to angular units using the configured mechanism radius. [[1]](diffhunk://#diff-d2e8adf374e82b768f0de7c44eae88deaf77586cadfe7c566352248e4caa079eR418-R443) [[2]](diffhunk://#diff-d2e8adf374e82b768f0de7c44eae88deaf77586cadfe7c566352248e4caa079eR476-R512)